### PR TITLE
Make all properties required

### DIFF
--- a/schemas/Building.yaml
+++ b/schemas/Building.yaml
@@ -2,6 +2,8 @@ type: object
 description: A physical building served by a parent heating system.
 required:
   - id
+  - name
+  - city
 properties:
   id:
     description: An ID, can be any unique ID defined by the implementer. Use URL friendly characters.

--- a/schemas/Error.yaml
+++ b/schemas/Error.yaml
@@ -1,5 +1,6 @@
 type: object
 required:
+  - code
   - message
 properties:
   code:

--- a/schemas/HeatingSystem.yaml
+++ b/schemas/HeatingSystem.yaml
@@ -3,8 +3,12 @@ description: >
   A heating system is a closed system with a connected hot water based energy source.
 required:
   - id
+  - name
   - feedTemperatureSensorId
   - returnTemperatureSensorId
+  - energyMeterSensorId
+  - outdoorTemperatureSensorId
+  - additionalEnergySources
 properties:
   id:
     description: An ID, can be any unique ID defined by the implementer. Use URL friendly characters.
@@ -32,6 +36,9 @@ properties:
     type: array
     items:
       type: object
+      required:
+        - sensorId
+        - description
       properties:
         sensorId:
           type: string

--- a/schemas/RadiatorLoop.yaml
+++ b/schemas/RadiatorLoop.yaml
@@ -2,6 +2,9 @@ type: object
 description: A radiator loop is the circuit serving the building with heating.
 required:
   - id
+  - feedTemperatureSensorId
+  - returnTemperatureSensorId
+  - energyMeterSensorId
 properties:
   id:
     description: An ID, can be any unique ID defined by the implementer. Use URL friendly characters.

--- a/schemas/Recommendation.yaml
+++ b/schemas/Recommendation.yaml
@@ -6,6 +6,9 @@ description: >
 
 required:
   - offset
+  - validFrom
+  - validTo
+  - agentId
 properties:
   offset:
     description: Recommended offset in degrees celcius from the configured heating curve.

--- a/schemas/Sensor.yaml
+++ b/schemas/Sensor.yaml
@@ -2,6 +2,8 @@ type: object
 description: A sensor is a thing providing observations.
 required:
   - id
+  - description
+  - unitOfMeasure
 properties:
   id:
     description: An ID, can be any unique ID defined by the implementer. Use URL friendly characters.


### PR DESCRIPTION
OpenAPI 3.0 does not seem to have a more foolproof way of doing this than to list everything.