### PR TITLE
Updated errors

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -41,8 +41,8 @@ paths:
                   $ref: "#/components/schemas/HeatingSystem"
         401:
           $ref: "#/components/responses/NotAuthorized"
-        500:
-          $ref: "#/components/responses/ServerError"
+        default:
+          $ref: "#/components/responses/UnexpectedError"
 
   /heatingsystems/{heatingSystemId}:
     get:
@@ -65,8 +65,8 @@ paths:
           $ref: "#/components/responses/NotAuthorized"
         404:
           $ref: "#/components/responses/NotFound"
-        500:
-          $ref: "#/components/responses/ServerError"
+        default:
+          $ref: "#/components/responses/UnexpectedError"
 
   /heatingsystems/{heatingSystemId}/heatingcurve:
     get:
@@ -88,8 +88,8 @@ paths:
           $ref: "#/components/responses/NotAuthorized"
         404:
           $ref: "#/components/responses/NotFound"
-        500:
-          $ref: "#/components/responses/ServerError"
+        default:
+          $ref: "#/components/responses/UnexpectedError"
 
   /heatingsystems/{heatingSystemId}/recommendation:
     post:
@@ -120,8 +120,8 @@ paths:
           $ref: "#/components/responses/NotAuthorized"
         404:
           $ref: "#/components/responses/NotFound"
-        500:
-          $ref: "#/components/responses/ServerError"
+        default:
+          $ref: "#/components/responses/UnexpectedError"
 
   ##################################################
   # RADIATOR LOOPS
@@ -150,8 +150,8 @@ paths:
           $ref: "#/components/responses/NotAuthorized"
         404:
           $ref: "#/components/responses/NotFound"
-        500:
-          $ref: "#/components/responses/ServerError"
+        default:
+          $ref: "#/components/responses/UnexpectedError"
 
   /heatingsystems/{heatingSystemId}/radiatorloops/{radiatorLoopId}/buildings:
     get:
@@ -177,8 +177,8 @@ paths:
           $ref: "#/components/responses/NotAuthorized"
         404:
           $ref: "#/components/responses/NotFound"
-        500:
-          $ref: "#/components/responses/ServerError"
+        default:
+          $ref: "#/components/responses/UnexpectedError"
 
   ? /heatingsystems/{heatingSystemId}/radiatorloops/{radiatorLoopId}/buildings/{buildingId}/temperaturesensors
   : get:
@@ -206,8 +206,8 @@ paths:
           $ref: "#/components/responses/NotAuthorized"
         404:
           $ref: "#/components/responses/NotFound"
-        500:
-          $ref: "#/components/responses/ServerError"
+        default:
+          $ref: "#/components/responses/UnexpectedError"
 
   ##################################################
   # SENSORS
@@ -234,8 +234,8 @@ paths:
           $ref: "#/components/responses/NotAuthorized"
         404:
           $ref: "#/components/responses/NotFound"
-        500:
-          $ref: "#/components/responses/ServerError"
+        default:
+          $ref: "#/components/responses/UnexpectedError"
 
   /sensors/{sensorId}/observations/latest:
     get:
@@ -260,8 +260,8 @@ paths:
           $ref: "#/components/responses/NotAuthorized"
         404:
           $ref: "#/components/responses/NotFound"
-        500:
-          $ref: "#/components/responses/ServerError"
+        default:
+          $ref: "#/components/responses/UnexpectedError"
 
   /sensors/{sensorId}/observations:
     description: >
@@ -303,8 +303,8 @@ paths:
           $ref: "#/components/responses/NotAuthorized"
         404:
           $ref: "#/components/responses/NotFound"
-        500:
-          $ref: "#/components/responses/ServerError"
+        default:
+          $ref: "#/components/responses/UnexpectedError"
 
 components:
   securitySchemes:
@@ -372,8 +372,8 @@ components:
         application/json:
           schema:
             $ref: "./schemas/Error.yaml"
-    ServerError:
-      description: An error occured.
+    UnexpectedError:
+      description: Unexpected error.
       content:
         application/json:
           schema:


### PR DESCRIPTION
## Default response
The generic 500 error response has been replaced with a default `UnexpectedError` response. 
From the OAS [docs](https://swagger.io/docs/specification/describing-responses/):

>  You can use the default response to describe these errors collectively, not individually. “Default” means this response is used for all HTTP codes that are not covered individually for this operation. 

So any response that is not explicitly defined should default to `UnexpectedError`. 

## 404-response body
I personally think it's better to have a uniform API for dealing with errors.
If all errors have a JSON response, you can always just decode the response instead of inspecting the status code header and branching depending on the error.

## Add 400 errors to the API
A 400 error response is added to the API wherever the an ID is present in the path or request parameters are used.
This response is useful to let the requester know that:
  * The ID is malformed rather than non-existing resource
  * Bad request parameter (the parameter is missing or of an unexpected type, for
  example)

This response makes the 404-response more informative.