### PR TITLE
Add connection object

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -77,7 +77,7 @@ paths:
         - $ref: '#/components/parameters/heatingSystemIdParam'
       responses:
         200:
-          description: heating system
+          description: supply connection
           content:
             application/json:
               schema:

--- a/api.yaml
+++ b/api.yaml
@@ -339,13 +339,6 @@ components:
       type: http
       scheme: bearer
   parameters:
-    connectionIdParam:
-      name: connectionId
-      in: path
-      required: true
-      description: unique ID
-      schema:
-        type: string
     heatingSystemIdParam:
       name: heatingSystemId
       in: path

--- a/api.yaml
+++ b/api.yaml
@@ -1,14 +1,15 @@
 openapi: "3.0.0"
 info:
-  version: 1.0.0
+  version: 1.0.0-beta
   title: Real Estate heating system API
   description: |
     API implemented by real estate owners. Exposes meta data, sensor observations and the
     capability of receiving heat system control recommendations from an external agent.
 
     Example use case of adding a new heating system to a recommendation agent and start making recommendations:
-    1. The agent system lists all available heating systems
-    1. The agent adds a heating system to its collection of managed systems
+    1. The agent system lists all available supply connections
+    1. The agent system lists all available heating systems connected to those connections
+    1. The agent adds newly discovered heating systems to its collection of managed systems
     1. The agent makes multiple calls to the /observations endpoint, creating a model of the heating system and its connected buildings.
     1. The agent begin its control cycle by making calls to the /observations/latest endpoint, calculates a posts target feed temperature recommendations to the /recommendations/ endpoint
     1. The agent recommendation is received by the local building automation system and used to adjust actuators
@@ -22,35 +23,80 @@ security:
   - bearerAuth: []
 paths:
   ##################################################
-  # HEATING SYSTEMS
+  # SUPPLY CONNECTIONS
   ##################################################
-  /heatingsystems:
+  /connections:
     get:
-      description: Lists all available heatingsystems.
+      description: Lists all available district heating supply connections.
       tags:
-        - Heating Systems
-      operationId: listHeatingSystems
+        - Supply connections
+      operationId: listSupplyConnections
       responses:
         200:
-          description: heating systems
+          description: supply connections
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/HeatingSystem"
+                  $ref: "#/components/schemas/SupplyConnection"
+        401:
+          $ref: "#/components/responses/NotAuthorized"
+        default:
+          $ref: "#/components/responses/UnexpectedError"
+  /connections/{connectionId}:
+    get:
+      description: Get metadata for a supply connection.
+      tags:
+        - Supply connections
+      operationId: getSupplyConnection
+      parameters:
+        - $ref: "#/components/parameters/connectionIdParam"
+      responses:
+        200:
+          description: supply connections
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/SupplyConnection"
         401:
           $ref: "#/components/responses/NotAuthorized"
         default:
           $ref: "#/components/responses/UnexpectedError"
 
-  /heatingsystems/{heatingSystemId}:
+  ##################################################
+  # HEATING SYSTEMS
+  ##################################################
+  /connections/{connectionId}/heatingsystems:
+    get:
+      description: Lists all heatingsystems supplied by a specific supply connection.
+      tags:
+        - Heating Systems
+      operationId: listHeatingSystems
+      parameters:
+        - $ref: "#/components/parameters/connectionIdParam"
+      responses:
+        200:
+          description: supply connection
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SupplyConnection"
+        401:
+          $ref: "#/components/responses/NotAuthorized"
+        default:
+          $ref: "#/components/responses/UnexpectedError"
+
+  /connections/{connectionId}/heatingsystems/{heatingSystemId}:
     get:
       description: Get metadata for a heatingsystem
       tags:
         - Heating Systems
       operationId: getHeatingSystem
       parameters:
+        - $ref: "#/components/parameters/connectionIdParam"
         - $ref: '#/components/parameters/heatingSystemIdParam'
       responses:
         200:
@@ -68,7 +114,7 @@ paths:
         default:
           $ref: "#/components/responses/UnexpectedError"
 
-  /heatingsystems/{heatingSystemId}/heatingcurve:
+  /connections/{connectionId}/heatingsystems/{heatingSystemId}/heatingcurve:
     get:
       description: >
         Returns the configured heating curve for this heating system.
@@ -78,6 +124,7 @@ paths:
         - Heating Systems
       operationId: getHeatingCurve
       parameters:
+        - $ref: "#/components/parameters/connectionIdParam"
         - $ref: '#/components/parameters/heatingSystemIdParam'
       responses:
         200:
@@ -95,13 +142,14 @@ paths:
         default:
           $ref: "#/components/responses/UnexpectedError"
 
-  /heatingsystems/{heatingSystemId}/recommendation:
+  /connections/{connectionId}/heatingsystems/{heatingSystemId}/recommendation:
     post:
       description: Posts a new recommendation for the heating system.
       tags:
         - Heating Systems
       operationId: updateRecommendation
       parameters:
+        - $ref: "#/components/parameters/connectionIdParam"
         - $ref: '#/components/parameters/heatingSystemIdParam'
       requestBody:
         description: Recommendation
@@ -131,13 +179,14 @@ paths:
   # RADIATOR LOOPS
   ##################################################
 
-  /heatingsystems/{heatingSystemId}/radiatorloops:
+  /connections/{connectionId}/heatingsystems/{heatingSystemId}/radiatorloops:
     get:
       description: List all radiatorloops connected to the heating system.
       tags:
         - Radiator loops
       operationId: listRadiatorLoops
       parameters:
+        - $ref: "#/components/parameters/connectionIdParam"
         - $ref: '#/components/parameters/heatingSystemIdParam'
       responses:
         200:
@@ -157,13 +206,14 @@ paths:
         default:
           $ref: "#/components/responses/UnexpectedError"
 
-  /heatingsystems/{heatingSystemId}/radiatorloops/{radiatorLoopId}/buildings:
+  /connections/{connectionId}/heatingsystems/{heatingSystemId}/radiatorloops/{radiatorLoopId}/buildings:
     get:
       description: List all buildings served by this radiator loop.
       tags:
         - Radiator loops
       operationId: listBuildnings
       parameters:
+        - $ref: "#/components/parameters/connectionIdParam"
         - $ref: '#/components/parameters/heatingSystemIdParam'
         - $ref: '#/components/parameters/radiatorLoopIdParam'
       responses:
@@ -184,13 +234,14 @@ paths:
         default:
           $ref: "#/components/responses/UnexpectedError"
 
-  ? /heatingsystems/{heatingSystemId}/radiatorloops/{radiatorLoopId}/buildings/{buildingId}/temperaturesensors
-  : get:
+  /connections/{connectionId}/heatingsystems/{heatingSystemId}/radiatorloops/{radiatorLoopId}/buildings/{buildingId}/temperaturesensors:
+    get:
       description: List all indoor temperature sensors in the building relevant for the agent.
       tags:
         - Radiator loops
       operationId: listTemperatureSensors
       parameters:
+        - $ref: "#/components/parameters/connectionIdParam"
         - $ref: '#/components/parameters/heatingSystemIdParam'
         - $ref: '#/components/parameters/radiatorLoopIdParam'
         - $ref: '#/components/parameters/buildingIdParam'
@@ -316,6 +367,13 @@ components:
       type: http
       scheme: bearer
   parameters:
+    connectionIdParam:
+      name: connectionId
+      in: path
+      required: true
+      description: unique ID
+      schema:
+        type: string
     heatingSystemIdParam:
       name: heatingSystemId
       in: path
@@ -345,6 +403,8 @@ components:
       schema:
         type: string
   schemas:
+    SupplyConnection:
+      $ref: "./schemas/SupplyConnection.yaml"
     HeatingSystem:
       $ref: "./schemas/HeatingSystem.yaml"
     RadiatorLoop:

--- a/api.yaml
+++ b/api.yaml
@@ -7,8 +7,7 @@ info:
     capability of receiving heat system control recommendations from an external agent.
 
     Example use case of adding a new heating system to a recommendation agent and start making recommendations:
-    1. The agent system lists all available supply connections
-    1. The agent system lists all available heating systems connected to those connections
+    1. The agent system lists all available heating systems
     1. The agent adds newly discovered heating systems to its collection of managed systems
     1. The agent makes multiple calls to the /observations endpoint, creating a model of the heating system and its connected buildings.
     1. The agent begin its control cycle by making calls to the /observations/latest endpoint, calculates a posts target feed temperature recommendations to the /recommendations/ endpoint
@@ -23,60 +22,14 @@ security:
   - bearerAuth: []
 paths:
   ##################################################
-  # SUPPLY CONNECTIONS
-  ##################################################
-  /connections:
-    get:
-      description: Lists all available district heating supply connections.
-      tags:
-        - Supply connections
-      operationId: listSupplyConnections
-      responses:
-        200:
-          description: supply connections
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/SupplyConnection"
-        401:
-          $ref: "#/components/responses/NotAuthorized"
-        default:
-          $ref: "#/components/responses/UnexpectedError"
-  /connections/{connectionId}:
-    get:
-      description: Get metadata for a supply connection.
-      tags:
-        - Supply connections
-      operationId: getSupplyConnection
-      parameters:
-        - $ref: "#/components/parameters/connectionIdParam"
-      responses:
-        200:
-          description: supply connections
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/SupplyConnection"
-        401:
-          $ref: "#/components/responses/NotAuthorized"
-        default:
-          $ref: "#/components/responses/UnexpectedError"
-
-  ##################################################
   # HEATING SYSTEMS
   ##################################################
-  /connections/{connectionId}/heatingsystems:
+  /heatingsystems:
     get:
-      description: Lists all heatingsystems supplied by a specific supply connection.
+      description: Lists all heatingsystems.
       tags:
         - Heating Systems
       operationId: listHeatingSystems
-      parameters:
-        - $ref: "#/components/parameters/connectionIdParam"
       responses:
         200:
           description: supply connection
@@ -91,14 +44,13 @@ paths:
         default:
           $ref: "#/components/responses/UnexpectedError"
 
-  /connections/{connectionId}/heatingsystems/{heatingSystemId}:
+  /heatingsystems/{heatingSystemId}:
     get:
       description: Get metadata for a heatingsystem
       tags:
         - Heating Systems
       operationId: getHeatingSystem
       parameters:
-        - $ref: "#/components/parameters/connectionIdParam"
         - $ref: '#/components/parameters/heatingSystemIdParam'
       responses:
         200:
@@ -115,8 +67,31 @@ paths:
           $ref: "#/components/responses/NotFound"
         default:
           $ref: "#/components/responses/UnexpectedError"
+  /heatingsystems/{heatingSystemId}/supplyconnection:
+    get:
+      description: Get metadata for a heatingsystems supply connection to the district heating network
+      tags:
+        - Heating Systems
+      operationId: getSupplyConnection
+      parameters:
+        - $ref: '#/components/parameters/heatingSystemIdParam'
+      responses:
+        200:
+          description: heating system
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SupplyConnection"
+        400:
+          $ref: "#/components/responses/BadRequest"
+        401:
+          $ref: "#/components/responses/NotAuthorized"
+        404:
+          $ref: "#/components/responses/NotFound"
+        default:
+          $ref: "#/components/responses/UnexpectedError"
 
-  /connections/{connectionId}/heatingsystems/{heatingSystemId}/heatingcurve:
+  /heatingsystems/{heatingSystemId}/heatingcurve:
     get:
       description: >
         Returns the configured heating curve for this heating system.
@@ -126,7 +101,6 @@ paths:
         - Heating Systems
       operationId: getHeatingCurve
       parameters:
-        - $ref: "#/components/parameters/connectionIdParam"
         - $ref: '#/components/parameters/heatingSystemIdParam'
       responses:
         200:
@@ -144,14 +118,13 @@ paths:
         default:
           $ref: "#/components/responses/UnexpectedError"
 
-  /connections/{connectionId}/heatingsystems/{heatingSystemId}/recommendation:
+  /heatingsystems/{heatingSystemId}/recommendation:
     post:
       description: Posts a new recommendation for the heating system.
       tags:
         - Heating Systems
       operationId: updateRecommendation
       parameters:
-        - $ref: "#/components/parameters/connectionIdParam"
         - $ref: '#/components/parameters/heatingSystemIdParam'
       requestBody:
         description: Recommendation
@@ -181,14 +154,13 @@ paths:
   # RADIATOR LOOPS
   ##################################################
 
-  /connections/{connectionId}/heatingsystems/{heatingSystemId}/radiatorloops:
+  /heatingsystems/{heatingSystemId}/radiatorloops:
     get:
       description: List all radiatorloops connected to the heating system.
       tags:
         - Radiator loops
       operationId: listRadiatorLoops
       parameters:
-        - $ref: "#/components/parameters/connectionIdParam"
         - $ref: '#/components/parameters/heatingSystemIdParam'
       responses:
         200:
@@ -208,14 +180,13 @@ paths:
         default:
           $ref: "#/components/responses/UnexpectedError"
 
-  /connections/{connectionId}/heatingsystems/{heatingSystemId}/radiatorloops/{radiatorLoopId}/buildings:
+  /heatingsystems/{heatingSystemId}/radiatorloops/{radiatorLoopId}/buildings:
     get:
       description: List all buildings served by this radiator loop.
       tags:
         - Radiator loops
       operationId: listBuildnings
       parameters:
-        - $ref: "#/components/parameters/connectionIdParam"
         - $ref: '#/components/parameters/heatingSystemIdParam'
         - $ref: '#/components/parameters/radiatorLoopIdParam'
       responses:
@@ -236,14 +207,13 @@ paths:
         default:
           $ref: "#/components/responses/UnexpectedError"
 
-  /connections/{connectionId}/heatingsystems/{heatingSystemId}/radiatorloops/{radiatorLoopId}/buildings/{buildingId}/temperaturesensors:
+  /heatingsystems/{heatingSystemId}/radiatorloops/{radiatorLoopId}/buildings/{buildingId}/temperaturesensors:
     get:
       description: List all indoor temperature sensors in the building relevant for the agent.
       tags:
         - Radiator loops
       operationId: listTemperatureSensors
       parameters:
-        - $ref: "#/components/parameters/connectionIdParam"
         - $ref: '#/components/parameters/heatingSystemIdParam'
         - $ref: '#/components/parameters/radiatorLoopIdParam'
         - $ref: '#/components/parameters/buildingIdParam'

--- a/api.yaml
+++ b/api.yaml
@@ -32,7 +32,7 @@ paths:
       operationId: listHeatingSystems
       responses:
         200:
-          description: supply connection
+          description: heating systems
           content:
             application/json:
               schema:

--- a/api.yaml
+++ b/api.yaml
@@ -83,7 +83,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/SupplyConnection"
+                type: array
+                items:
+                  $ref: "#/components/schemas/HeatingSystem"
         401:
           $ref: "#/components/responses/NotAuthorized"
         default:

--- a/schemas/Building.yaml
+++ b/schemas/Building.yaml
@@ -11,8 +11,6 @@ properties:
   name:
     type: string
     description: Building name or street name(s)
-  location:
-    $ref: './Location.yaml'
   alternateIds:
     description: >
       A collection of alternate keys by which a building can be identified. Implemented as string-to-string key-value pairs. Intended usage is

--- a/schemas/HeatingSystem.yaml
+++ b/schemas/HeatingSystem.yaml
@@ -9,7 +9,7 @@ required:
   #- energyMeterSensorId
   - outdoorTemperatureSensorId
   - additionalEnergySources
-  #- location
+  - location
 properties:
   id:
     description: An ID, can be any unique ID defined by the implementer. Use URL friendly characters.
@@ -64,3 +64,5 @@ properties:
         description:
           type: string
           description: Description of the energy source
+  location:
+    $ref: "./Location.yaml"

--- a/schemas/HeatingSystem.yaml
+++ b/schemas/HeatingSystem.yaml
@@ -30,6 +30,9 @@ properties:
   outdoorTemperatureSensorId:
     type: string
     description: The ID of the outdoor temperature sensor.
+  isSubsystemTo:
+    type: string
+    description: The ID of the superior heating system.
   alternateIds:
     description: >
       A collection of alternate keys by which the heating system can be identified. Implemented as string-to-string key-value pairs.

--- a/schemas/RadiatorLoop.yaml
+++ b/schemas/RadiatorLoop.yaml
@@ -4,7 +4,7 @@ required:
   - id
   - feedTemperatureSensorId
   - returnTemperatureSensorId
-  - energyMeterSensorId
+  #- energyMeterSensorId
 properties:
   id:
     description: An ID, can be any unique ID defined by the implementer. Use URL friendly characters.

--- a/schemas/SupplyConnection.yaml
+++ b/schemas/SupplyConnection.yaml
@@ -42,10 +42,5 @@ properties:
       complicated_composite_id.cost_location: "Financial Department 1"
       complicated_composite_id.cost_location_id: "17"
       supplier.id: "E.On"
-  owner:
-    description: >
-      Optional information regarding the owner of the Heating System. Primary use case is when the api provider manages
-      real estates belonging to different branches/companies.
-    type: string
   location:
     $ref: "./Location.yaml"

--- a/schemas/SupplyConnection.yaml
+++ b/schemas/SupplyConnection.yaml
@@ -1,15 +1,14 @@
 type: object
 description: >
-  A heating system is a closed system with a connected hot water based energy source.
+  A connection denotes a physical connection to a district heating supplier.
+  Contains the metadata regarding the sensors on the supply-side of district heating heat exchanger.
 required:
   - id
   - name
   - feedTemperatureSensorId
   - returnTemperatureSensorId
-  #- energyMeterSensorId
-  - outdoorTemperatureSensorId
-  - additionalEnergySources
-  #- location
+  - energyMeterSensorId
+  - location
 properties:
   id:
     description: An ID, can be any unique ID defined by the implementer. Use URL friendly characters.
@@ -26,41 +25,27 @@ properties:
     description: The ID of the water return temperature sensor.
   energyMeterSensorId:
     type: string
-    description: The ID of the water energy meter.
-  outdoorTemperatureSensorId:
+    description: The ID of the supply water energy meter.
+  groupId:
     type: string
-    description: The ID of the outdoor temperature sensor.
+    description: An id to optionally denote a logical grouping of supply connections.
   alternateIds:
     description: >
-      A collection of alternate keys by which the heating system can be identified. Implemented as string-to-string key-value pairs.
+      A collection of alternate keys by which the connection can be identified. Implemented as string-to-string key-value pairs.
       Intended usage is to be able to link to other systems.
     type: object
     additionalProperties:
       type: string
       maxLength: 256
     example:
-      modbus_id: "13"
+      EON.id: "7"
       complicated_composite_id.cost_location: "Financial Department 1"
       complicated_composite_id.cost_location_id: "17"
+      supplier.id: "E.On"
   owner:
     description: >
       Optional information regarding the owner of the Heating System. Primary use case is when the api provider manages
       real estates belonging to different branches/companies.
     type: string
-  additionalEnergySources:
-    description: >
-      A list of additional energy sources. Could be a system like a geothermal heat pump or 
-      different kinds of heat recovery systems only active at certain peak demand times or certain parts of the year.
-    type: array
-    items:
-      type: object
-      required:
-        - sensorId
-        - description
-      properties:
-        sensorId:
-          type: string
-          description: The ID of the energy meter.
-        description:
-          type: string
-          description: Description of the energy source
+  location:
+    $ref: "./Location.yaml"

--- a/schemas/TemperatureCurve.yaml
+++ b/schemas/TemperatureCurve.yaml
@@ -4,6 +4,8 @@ description: >
   where each breakpoint indicates the supplied feedTemperature for a given outdoorTemperature.
 required:
   - breakpoints
+  - minFeedTemperature
+  - maxFeedTemperature
 properties:
   breakpoints:
     type: array
@@ -21,6 +23,14 @@ properties:
         feedTemperature: 75.0
       - outdoorTemperature: 0.0
         feedTemperature: 57.0
+  minFeedTemperature:
+    type: number
+    description: The minimum temperature that the Temperature Curve controller is configured to output. Null can be used to signal that the breakpoint values can be extrapolated.
+    example: 20.0
+  maxFeedTemperature:
+    type: number
+    description: The maximum temperature that the Temperature Curve controller is configured to output. Null can be used to signal that the breakpoint values can be extrapolated.
+    example: 80.0
   lastModifiedAt:
     type: string
     description: >

--- a/schemas/TemperatureCurve.yaml
+++ b/schemas/TemperatureCurve.yaml
@@ -13,6 +13,9 @@ properties:
       type: object
       description: >
         feedTemperature, outdoorTemperature pair. Provided in the same unitOfMeasure as the corresponding sensors.
+      required:
+        - feedTemperature
+        - outdoorTemperature
       properties:
         outdoorTemperature:
           type: number


### PR DESCRIPTION
Add a top level SupplyConnection object, to indicate the physical connection to the district heating provider.

Move location information to this top level.

Make energyMeterSensorId optional at and below the HeatingSystem-level.

Add min/maxFeedTemperature on the TemperatureCurve object.

Points of uncertainty:
- The moving of the location object to be associated with a connection.
- Offsetting the entire API hierarchy by using SupplyConnection as a root object may be inconvenient to implement, given existing implementations. An option could be to assign a "connectionId" field to the HeatingSystem model and have both /heatingsystems/ and /connections/ as root objects.
- owner (which is optional) now lives on both Connection and HeatingSystem. It may be more logical to have it only on the connection level, which might however be confusing since it is the supplier that actually owns the connection.
