### PR TITLE
add endpoint for a batched list of sensor observations

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -233,7 +233,30 @@ paths:
   ##################################################
   # SENSORS
   ##################################################
-
+  /sensors/observations/latest:
+    get:
+      description: >
+        Returns the most recent observations of the queried list of sensors
+      tags:
+        - Sensors
+      operationId: getLatestSensorObservationsBySensorIds
+      parameters:
+        - $ref: '#/components/parameters/sensorIdListParam'
+      responses:
+        200:
+          description: latest observations
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TaggedObservations"
+        400:
+          $ref: "#/components/responses/BadRequest"
+        401:
+          $ref: "#/components/responses/NotAuthorized"
+        404:
+          $ref: "#/components/responses/NotFound"
+        default:
+          $ref: "#/components/responses/UnexpectedError"
   /sensors/{sensorId}:
     get:
       description: Metadata for a sensor.
@@ -257,7 +280,6 @@ paths:
           $ref: "#/components/responses/NotFound"
         default:
           $ref: "#/components/responses/UnexpectedError"
-
   /sensors/{sensorId}/observations/latest:
     get:
       description: >
@@ -326,7 +348,6 @@ paths:
           $ref: "#/components/responses/NotFound"
         default:
           $ref: "#/components/responses/UnexpectedError"
-
 components:
   securitySchemes:
     bearerAuth:
@@ -361,6 +382,16 @@ components:
       description: unique ID
       schema:
         type: string
+    sensorIdListParam:
+      name: sensorIds
+      in: query
+      required: true
+      description: array of unique IDs
+      schema:
+        type: array
+        items:
+          type: string
+          maxLength: 36
   schemas:
     SupplyConnection:
       $ref: "./schemas/SupplyConnection.yaml"
@@ -378,6 +409,8 @@ components:
       $ref: "./schemas/Sensor.yaml"
     TemperatureCurve:
       $ref: "./schemas/TemperatureCurve.yaml"
+    TaggedObservations:
+      $ref: "./schemas/TaggedObservations.yaml"
   responses:
     BadRequest:
       description: The request cannot be processed.

--- a/schemas/TaggedObservations.yaml
+++ b/schemas/TaggedObservations.yaml
@@ -1,0 +1,19 @@
+type: array
+items:
+  type: object
+  required:
+    - observationTime
+    - value
+    - sensorId
+  properties:
+    sensorId:
+      description: The id of the sensor that the value pertains to
+      type: string
+      maxLength: 36
+    observationTime:
+      description: The timestamp of the observed value.
+      type: string
+      format: date-time
+    value:
+      type: number
+      description: The observed value


### PR DESCRIPTION
## Rationale

The current spec requires many api-calls to get the latest sensor values for a single "unit of interest", i.e., a single `heatingSystem`. This causes heavy server load, and associated high costs.

By providing an endpoint to get sensor values in a batched manner, the server load, and costs, could be reduced.

##Discussion points

The proposed implementation is REST-correct, in that getting a batch of sensor values is a `GET`-request. However, this requires the `sensorId`-params to be encoded in the query. Given that `sensorId`s have a max length of 36, and the max length of a URL is 2048 characters, this limits the client to reliably requesting at most maybe ~40 sensors at a time. This in and of itself could be like a reasonable limit to avoid server timeouts anyway, however it can be a source of very confusing errors since the limit is not explicit. This could be handled in two ways

- Set an explicit limit in the schema for the number of sensorIds for the endpoint
- Skip REST-compliance and make the endpoint a `POST`, with the sensorIds sent in the a JSON-body.