### PR TITLE
add a sensor id indicating whether the system is active

### DIFF
--- a/schemas/RadiatorLoop.yaml
+++ b/schemas/RadiatorLoop.yaml
@@ -19,3 +19,7 @@ properties:
   energyMeterSensorId:
     type: string
     description: The ID of the energy meter.
+  isActiveSensorId:
+    type: string
+    description: The ID of the sensor indicating whether the system is currently active
+

--- a/schemas/Sensor.yaml
+++ b/schemas/Sensor.yaml
@@ -18,3 +18,4 @@ properties:
     enum:
       - degC
       - Wh
+      - dimensionless


### PR DESCRIPTION
We currently have no knowledge of the current activity state of the system. This causes issues with reporting and model fitting on our end, especially at the start of the heating season. I believe we need to pass this information in some way.

This PR simply adds an optional activity sensor to the schema, which should indicate whether the system is active. In this version, the sensor data would be `dimensionless` float values.

## Alternatives

- Instead of an "activity" sensor, we could add a sensor for the current flow rate. This would allow us to improve reporting, since estimation of the power draw becomes much easier. I am however uncertain whether a physical sensor of the flow rate exists.
- Instead of providing a sensor id for activity, we could use an `isActive` boolean field. The data would then be the correct type, but data would then be passed in a manner not consistent with the rest of the schema. 